### PR TITLE
amd-bmc-ubm: Put the macros within parentheses

### DIFF
--- a/inc/ubm_common.h
+++ b/inc/ubm_common.h
@@ -89,6 +89,8 @@
 //BP unique ID
 #define BP_ID_NONE                                                  0xC0
 #define BP_ID_2U_2_5_Anybay_8_Bay                                   0xC1
+#define BP_ID_2U_U3_Anybay_8_Bay                                    0xD1
+
 
 //BP auto configuration offset
 #define BP_CONTROL_REGISTER_GROUP_ID                                0x0D

--- a/inc/ubm_common.h
+++ b/inc/ubm_common.h
@@ -62,75 +62,75 @@
 
 // Add form Lenovo
 //BP PSoC count
-#define BP_TOTAL_SEP_0                                              0
-#define BP_TOTAL_SEP_1                                              1
-#define BP_TOTAL_SEP_2                                              2
-#define BP_TOTAL_SEP_3                                              3
+#define BP_TOTAL_SEP_0                                              (0)
+#define BP_TOTAL_SEP_1                                              (1)
+#define BP_TOTAL_SEP_2                                              (2)
+#define BP_TOTAL_SEP_3                                              (3)
 
 //BP BAY count
-#define BP_TOTAL_BAY_2                                              2
-#define BP_TOTAL_BAY_4                                              4
-#define BP_TOTAL_BAY_6                                              6
-#define BP_TOTAL_BAY_8                                              8
-#define BP_TOTAL_BAY_10                                             10
-#define BP_TOTAL_BAY_12                                             12
+#define BP_TOTAL_BAY_2                                              (2)
+#define BP_TOTAL_BAY_4                                              (4)
+#define BP_TOTAL_BAY_6                                              (6)
+#define BP_TOTAL_BAY_8                                              (8)
+#define BP_TOTAL_BAY_10                                             (10)
+#define BP_TOTAL_BAY_12                                             (12)
 
 //BP group ID
-#define BP_Group_ID_4                                               4
-#define BP_Group_ID_8                                               8
+#define BP_Group_ID_4                                               (4)
+#define BP_Group_ID_8                                               (8)
 
 //BP type ID
-#define BP_TYPE_SAS_SATA                                            0x01
-#define BP_TYPE_ANYBAY                                              0x02
-#define BP_TYPE_NVME                                                0x03
-#define BP_TYPE_EDSFF                                               0x04
-#define BP_TOTAL_CONNECTOR                                          8
+#define BP_TYPE_SAS_SATA                                            (0x01)
+#define BP_TYPE_ANYBAY                                              (0x02)
+#define BP_TYPE_NVME                                                (0x03)
+#define BP_TYPE_EDSFF                                               (0x04)
+#define BP_TOTAL_CONNECTOR                                          (8)
 
 //BP unique ID
-#define BP_ID_NONE                                                  0xC0
-#define BP_ID_2U_2_5_Anybay_8_Bay                                   0xC1
-#define BP_ID_2U_U3_Anybay_8_Bay                                    0xD1
+#define BP_ID_NONE                                                  (0xC0)
+#define BP_ID_2U_2_5_Anybay_8_Bay                                   (0xC1)
+#define BP_ID_2U_U3_Anybay_8_Bay                                    (0xD1)
 
 
 //BP auto configuration offset
-#define BP_CONTROL_REGISTER_GROUP_ID                                0x0D
-#define BP_CONTROL_REGISTER_SLOT_ID                                 0x12
-#define BP_CONTROL_REGISTER_BAY_ID                                  0x13
-#define BP_CONTROL_REGISTER_VMD_CONFIGURATION                       0x15
-#define BP_CONTROL_REGISTER_BACKPLANE_INFO                          0x16
-#define BP_CONTROL_REGISTER_NUM_OF_SLOTS                            0x17
-#define BP_CONTROL_REGISTER_START_SLOT_NUM                          0x18
-#define BP_CONTROL_REGISTER_START_HFC_IDENTITY                      0x19
-#define BP_CONTROL_REGISTER_SYSTEM_MGMT_PROTOCOL                    0x1A
-#define BP_CONTROL_REGISTER_AUTO_CONFIG_ENABLE                      0x0E
-#define BP_CONTROL_REGISTER_YELLOW_LED_SLOT_0_1                     0x22
-#define BP_CONTROL_REGISTER_PGOOD                                   0x46
+#define BP_CONTROL_REGISTER_GROUP_ID                                (0x0D)
+#define BP_CONTROL_REGISTER_SLOT_ID                                 (0x12)
+#define BP_CONTROL_REGISTER_BAY_ID                                  (0x13)
+#define BP_CONTROL_REGISTER_VMD_CONFIGURATION                       (0x15)
+#define BP_CONTROL_REGISTER_BACKPLANE_INFO                          (0x16)
+#define BP_CONTROL_REGISTER_NUM_OF_SLOTS                            (0x17)
+#define BP_CONTROL_REGISTER_START_SLOT_NUM                          (0x18)
+#define BP_CONTROL_REGISTER_START_HFC_IDENTITY                      (0x19)
+#define BP_CONTROL_REGISTER_SYSTEM_MGMT_PROTOCOL                    (0x1A)
+#define BP_CONTROL_REGISTER_AUTO_CONFIG_ENABLE                      (0x0E)
+#define BP_CONTROL_REGISTER_YELLOW_LED_SLOT_0_1                     (0x22)
+#define BP_CONTROL_REGISTER_PGOOD                                   (0x46)
 
 //BP PSoC relative reg
-#define BP_SLAVE_ADDR_SEP_NVME_MUX                                  0x73            /* 8-bit address: 0xE6 */
-#define BP_SLAVE_ADDR_SEP_STATUS_REG                                0x20            /* 8-bit address: 0x40 */
-#define BP_SLAVE_ADDR_SEP_CONTROL_REG                               0x60            /* 8-bit address: 0xC0 */
+#define BP_SLAVE_ADDR_SEP_NVME_MUX                                  (0x73)            /* 8-bit address: 0xE6 */
+#define BP_SLAVE_ADDR_SEP_STATUS_REG                                (0x20)            /* 8-bit address: 0x40 */
+#define BP_SLAVE_ADDR_SEP_CONTROL_REG                               (0x60)            /* 8-bit address: 0xC0 */
 
 //BP FRU
-#define SYS_EEPROM_PATH_LENGTH                                      64
-#define BP_FRU_BOARD_PRODUCT_OFFSET                                 0x16
-#define BP_FRU_BOARD_PRODUCT_SIZE                                   40
+#define SYS_EEPROM_PATH_LENGTH                                      (64)
+#define BP_FRU_BOARD_PRODUCT_OFFSET                                 (0x16)
+#define BP_FRU_BOARD_PRODUCT_SIZE                                   (40)
 
 
-#define BP_SYSTEM_TYPE_INTEL_GP                                     0x00
-#define BP_SYSTEM_TYPE_AMD_GP                                       0x20
-#define BP_SYSTEM_TYPE_INTEL_HS                                     0x40
-#define BP_SYSTEM_TYPE_AMD_HS                                       0x60
+#define BP_SYSTEM_TYPE_INTEL_GP                                     (0x00)
+#define BP_SYSTEM_TYPE_AMD_GP                                       (0x20)
+#define BP_SYSTEM_TYPE_INTEL_HS                                     (0x40)
+#define BP_SYSTEM_TYPE_AMD_HS                                       (0x60)
 
-#define BP_MANAGEMENT_PROTOCOL_SGPIO_I2CHP                          0x03
-#define BP_MANAGEMENT_PROTOCOL_I2CHP_UBM                            0x06
-#define BP_MANAGEMENT_PROTOCOL_SGPIO_I2CHP_UBM                      0x07
+#define BP_MANAGEMENT_PROTOCOL_SGPIO_I2CHP                          (0x03)
+#define BP_MANAGEMENT_PROTOCOL_I2CHP_UBM                            (0x06)
+#define BP_MANAGEMENT_PROTOCOL_SGPIO_I2CHP_UBM                      (0x07)
 
 
-#define PREFIX_BPBUS "/dev/i2c-2%d"
-#define BP1_FRU_PATH "/sys/bus/i2c/devices/250-0050/eeprom"
-#define BP2_FRU_PATH "/sys/bus/i2c/devices/251-0050/eeprom"
-#define BP3_FRU_PATH "/sys/bus/i2c/devices/252-0050/eeprom"
+#define PREFIX_BPBUS ("/dev/i2c-2%d")
+#define BP1_FRU_PATH ("/sys/bus/i2c/devices/250-0050/eeprom")
+#define BP2_FRU_PATH ("/sys/bus/i2c/devices/251-0050/eeprom")
+#define BP3_FRU_PATH ("/sys/bus/i2c/devices/252-0050/eeprom")
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ const BP_Info BP_Table_List[] =
         /* BP Name in FRU,                  BP ID (BP Type Code),           BP Total SEP,       BP Total Bay        BP Type,                BP Group ID         HFC */
         {"None",                            BP_ID_NONE,                     BP_TOTAL_SEP_0,     BP_TOTAL_BAY_8,     BP_TYPE_ANYBAY,         BP_Group_ID_4,      {0, 0}        },
         {"2U 2.5\" Anybay 8-Bay BP",        BP_ID_2U_2_5_Anybay_8_Bay,      BP_TOTAL_SEP_2,     BP_TOTAL_BAY_8,     BP_TYPE_ANYBAY,         BP_Group_ID_4,      {0, 5}        },
+        {"2U Volcano U.3 8-Bay BP",         BP_ID_2U_U3_Anybay_8_Bay,       BP_TOTAL_SEP_1,     BP_TOTAL_BAY_8,     BP_TYPE_NVME,           BP_Group_ID_4,      {0, 5}        },
 };
 const int BP_Table_List_Count = (sizeof(BP_Table_List) / sizeof(BP_Table_List[0]));
 
@@ -259,7 +260,7 @@ int Check_BP_Auto_Configuration_Register(char* bus_name, uint8_t which_bp, uint8
 
 
 
-/* Auto-Configuration Step 1 – Range of values are 1-8; by 4 or by 8 group.
+/* Auto-Configuration Step 1 Range of values are 1-8; by 4 or by 8 group.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
  * arg: which_sep (which SEP in a BP)
@@ -283,7 +284,7 @@ int Check_BP_Group_ID(char* bus_name, uint8_t which_bp, uint8_t which_sep)
     return ret;
 }
 
-/* Auto-Configuration Step 2 – This is the PCIe slot information.
+/* Auto-Configuration Step 2 This is the PCIe slot information.
  * This step is skipped in SAS/SATA only BP.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
@@ -300,7 +301,7 @@ int Check_BP_Slot_ID(char* bus_name, uint8_t which_bp, uint8_t which_sep)
     return ret;
 }
 
-/* Auto-Configuration Step 3 – This is the physical backplane Bay location in the enclosure.
+/* Auto-Configuration Step 3 This is the physical backplane Bay location in the enclosure.
  * This step is skipped in SAS/SATA only BP.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
@@ -317,7 +318,7 @@ int Check_BP_Bay_ID(char* bus_name, uint8_t which_bp, uint8_t which_sep)
     return ret;
 }
 
-/* Auto-Configuration Step 4 –  This register describe the backplane configuration.
+/* Auto-Configuration Step 4 This register describe the backplane configuration.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
  * arg: which_sep (which SEP in a BP)
@@ -333,7 +334,7 @@ int Check_BP_Backplane_Information(char* bus_name, uint8_t which_bp, uint8_t whi
     return ret;
 }
 
-/* Auto-Configuration Step 5 – Indicates the number of slots/bays on the backplane.
+/* Auto-Configuration Step 5 Indicates the number of slots/bays on the backplane.
  * Each SEP on a backplane receive the same number of slots.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
@@ -350,7 +351,7 @@ int Check_BP_Number_of_Slots(char* bus_name, uint8_t which_bp, uint8_t which_sep
     return ret;
 }
 
-/* Auto-Configuration Step 6 – Indicating the starting physical backplane bay location for each SEP.
+/* Auto-Configuration Step 6 Indicating the starting physical backplane bay location for each SEP.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
  * arg: which_sep (which SEP in a BP)
@@ -366,7 +367,7 @@ int Check_BP_Starting_Slot_Number(char* bus_name, uint8_t which_bp, uint8_t whic
     return ret;
 }
 
-/* Auto-Configuration Step 7 – Indicate type of system and supported management protocol.
+/* Auto-Configuration Step 7 Indicate type of system and supported management protocol.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
  * arg: which_sep (which SEP in a BP)
@@ -382,7 +383,7 @@ int Check_BP_Starting_Host_Facing_Connector_Identity(char* bus_name, uint8_t whi
     return ret;
 }
 
-/* Auto-Configuration Step 8 – Indicate type of system and supported management protocol.
+/* Auto-Configuration Step 8 Indicate type of system and supported management protocol.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)
  * arg: which_sep (which SEP in a BP)
@@ -398,7 +399,7 @@ int Check_BP_System_Type_Managment_Protocol_Support(char* bus_name, uint8_t whic
     return ret;
 }
 
-/* Auto-Configuration Step 9 – Auto-configuration enable register is set by the BMC to 0xBE (enable).
+/* Auto-Configuration Step 9 Auto-configuration enable register is set by the BMC to 0xBE (enable).
  * STEPS 1-8 MUST BE PERFORMED PRIOR TO EXECUTING STEP 9.
  * arg: bus_name (i2c bus name for BP)
  * arg: which_bp (BP connector offset)


### PR DESCRIPTION
 - To support Volcano U.3 BP auto configuration.